### PR TITLE
Version 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "eris": "^0.14.0",
     "log4js": "^6.3.0",
-    "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "^0.13.7",
     "typeorm": "^0.2.29"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxz/blueprint",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A modern, powerful, experimental, and modular Discord bot framework",
   "main": "build/index.js",
   "repository": "git@github.com:xpyxel/blueprint.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 dependencies:
   eris: 0.14.0
   log4js: 6.3.0
-  reflect-metadata: 0.1.13
   regenerator-runtime: 0.13.7
   typeorm: 0.2.30
 devDependencies:
@@ -2812,7 +2811,6 @@ specifiers:
   eris: ^0.14.0
   gts: ^3.0.2
   log4js: ^6.3.0
-  reflect-metadata: ^0.1.13
   regenerator-runtime: ^0.13.7
   typeorm: ^0.2.29
   typescript: ^4.1.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line node/no-unpublished-import
-import 'reflect-metadata';
-
 export {
   BaseConfig,
   BotOptions,
@@ -17,7 +14,7 @@ export {
 } from './lib/util/hook';
 
 export {Blueprint, Extension, Internals, Registries} from './lib/class/client';
-export {Command, Executor, CommandMeta} from './lib/class/command';
+export {Command, CommandMeta} from './lib/class/command';
 export {PermissionString} from './lib/util/permissions';
 export {Group, Override} from './lib/registry/groups';
 export {ClientEvents} from './lib/util/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,7 @@ export {
   ConnectionOptions,
 } from './lib/util/config';
 
-export {
-  bindHooks,
-  unbindHooks,
-  HookCallback,
-  HookResponse,
-} from './lib/util/hook';
-
+export {Hook, HookCallback, HookResponse} from './lib/util/hook';
 export {Blueprint, Extension, Internals, Registries} from './lib/class/client';
 export {Command, CommandMeta, Guard} from './lib/class/command';
 export {PermissionString} from './lib/util/permissions';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export {
 } from './lib/util/hook';
 
 export {Blueprint, Extension, Internals, Registries} from './lib/class/client';
-export {Command, CommandMeta} from './lib/class/command';
+export {Command, CommandMeta, Guard} from './lib/class/command';
 export {PermissionString} from './lib/util/permissions';
 export {Group, Override} from './lib/registry/groups';
 export {ClientEvents} from './lib/util/types';

--- a/src/lib/class/client.ts
+++ b/src/lib/class/client.ts
@@ -15,7 +15,7 @@ export interface Internals<T extends BaseConfig> {
 }
 
 export interface Registries<T extends BaseConfig> {
-  commands: CommandRegistry;
+  commands: CommandRegistry<T>;
   events: EventRegistry<T>;
   groups: GroupRegistry;
   data: {get: (key: string) => unknown};
@@ -37,7 +37,7 @@ export class Blueprint<T extends BaseConfig> {
   private readonly database?: TypeORM;
   private readonly events: EventRegistry<T>;
   private readonly groups: GroupRegistry;
-  private readonly commands: CommandRegistry;
+  private readonly commands: CommandRegistry<T>;
   private readonly data: DataRegistry;
 
   /**

--- a/src/lib/class/command.ts
+++ b/src/lib/class/command.ts
@@ -9,23 +9,15 @@ export interface CommandMeta {
 }
 
 /**
- * Decorator used to define the properties of a command
- * @param meta The metadata to use for the command
- * @constructor
- */
-export function Command(meta: CommandMeta) {
-  return function (target: Function) {
-    Reflect.defineMetadata('meta', meta, target.prototype);
-  };
-}
-
-/**
  * Interface used to enforce the callback signature of a command
  */
-export interface Executor {
-  callback<T extends BaseConfig>(
-    ctx: Message,
-    args: Array<string>,
-    ref: Blueprint<T>
-  ): void;
+export abstract class Command<T extends BaseConfig> {
+  public readonly meta: CommandMeta;
+  constructor(
+    name: string,
+    meta: {aliases: Array<string>; groups: Array<string>}
+  ) {
+    this.meta = {name, ...meta};
+  }
+  abstract callback(ctx: Message, args: Array<string>, ref: Blueprint<T>): void;
 }

--- a/src/lib/class/command.ts
+++ b/src/lib/class/command.ts
@@ -2,21 +2,30 @@ import {Message} from 'eris';
 import {Blueprint} from '../class/client';
 import {BaseConfig} from '../util/config';
 
-export interface CommandMeta {
+export interface CommandMeta<T extends BaseConfig> {
   name: string;
   aliases: Array<string>;
   groups: Array<string>;
+  guards?: Array<Guard<T>>;
 }
+
+interface PartialMeta<T extends BaseConfig> {
+  aliases: Array<string>;
+  groups: Array<string>;
+  guards?: Array<Guard<T>>;
+}
+
+export type Guard<T extends BaseConfig> = (
+  ctx: Message,
+  ref: Blueprint<T>
+) => boolean;
 
 /**
  * Interface used to enforce the callback signature of a command
  */
 export abstract class Command<T extends BaseConfig> {
-  public readonly meta: CommandMeta;
-  constructor(
-    name: string,
-    meta: {aliases: Array<string>; groups: Array<string>}
-  ) {
+  public readonly meta: CommandMeta<T>;
+  constructor(name: string, meta: PartialMeta<T>) {
     this.meta = {name, ...meta};
   }
   abstract callback(ctx: Message, args: Array<string>, ref: Blueprint<T>): void;

--- a/src/lib/registry/commands.ts
+++ b/src/lib/registry/commands.ts
@@ -45,8 +45,12 @@ export class CommandRegistry<T extends BaseConfig> extends AutoRegistry<
   ) {
     for (const {value} of this.items) {
       if (value.meta.aliases.includes(cmd) || value.meta.name === cmd) {
-        if (ref.registry.groups.validate(user, value.meta.groups))
+        if (
+          ref.registry.groups.validate(user, value.meta.groups) &&
+          value.meta.guards?.every(g => g(msg, ref) === false)
+        ) {
           value.callback(msg, args, ref);
+        }
         this.executeHook({
           message: 'Execute Command',
           data: {

--- a/src/lib/registry/commands.ts
+++ b/src/lib/registry/commands.ts
@@ -47,7 +47,7 @@ export class CommandRegistry<T extends BaseConfig> extends AutoRegistry<
       if (value.meta.aliases.includes(cmd) || value.meta.name === cmd) {
         if (
           ref.registry.groups.validate(user, value.meta.groups) &&
-          value.meta.guards?.every(g => g(msg, ref) === false)
+          value.meta.guards?.every(g => g(msg, ref) === true)
         ) {
           value.callback(msg, args, ref);
         }

--- a/src/lib/registry/commands.ts
+++ b/src/lib/registry/commands.ts
@@ -1,19 +1,18 @@
 import {Member, Message, User} from 'eris';
 import {AutoRegistry} from '../class/registry';
-import {CommandMeta, Executor} from '../class/command';
+import {Command} from '../class/command';
 import {Blueprint} from '../class/client';
 import {BaseConfig} from '../util/config';
 
-type Command = {new (...args: Array<unknown>): unknown};
-
-export class CommandRegistry extends AutoRegistry<Command> {
+export class CommandRegistry<T extends BaseConfig> extends AutoRegistry<
+  Command<T>
+> {
   /**
    * Registers a new command
    * @param value The command class to register
    */
-  register(value: Command): void {
-    const meta = Reflect.getMetadata('meta', value.prototype) as CommandMeta;
-    const commandData = {key: meta.name, value};
+  register(value: Command<T>): void {
+    const commandData = {key: value.meta.name, value};
     this.executeHook({message: 'Register Command', data: commandData});
     this.items.push(commandData);
   }
@@ -31,25 +30,13 @@ export class CommandRegistry extends AutoRegistry<Command> {
   }
 
   /**
-   * Returns the metadata of a command
-   * @param name The name of the command
-   */
-  meta(name: string): CommandMeta {
-    const item = this.items.find(i => i.key === name);
-    if (item) {
-      this.executeHook({message: 'Command Meta', data: item});
-      return Reflect.getMetadata('meta', item.value.prototype);
-    } else throw new Error(`Unable to find command with name '${name}'`);
-  }
-
-  /**
    * Executes a command if the user has permissions to
    * @param cmd The name of the command
    * @param msg The message context
    * @param user The user to check groups of
    * @param ref The blueprint instance
    */
-  execute<T extends BaseConfig>(
+  execute(
     cmd: string,
     msg: Message,
     user: User | Member,
@@ -57,15 +44,14 @@ export class CommandRegistry extends AutoRegistry<Command> {
     ref: Blueprint<T>
   ) {
     for (const {value} of this.items) {
-      const meta = Reflect.getMetadata('meta', value.prototype) as CommandMeta;
-      if (meta.aliases.includes(cmd) || meta.name === cmd) {
-        if (ref.registry.groups.validate(user, meta.groups))
-          (new value() as Executor).callback(msg, args, ref);
+      if (value.meta.aliases.includes(cmd) || value.meta.name === cmd) {
+        if (ref.registry.groups.validate(user, value.meta.groups))
+          value.callback(msg, args, ref);
         this.executeHook({
           message: 'Execute Command',
           data: {
-            validated: ref.registry.groups.validate(user, meta.groups),
-            meta,
+            validated: ref.registry.groups.validate(user, value.meta.groups),
+            meta: value.meta,
             cmd,
             msg,
             user,

--- a/src/lib/registry/groups.ts
+++ b/src/lib/registry/groups.ts
@@ -59,7 +59,6 @@ export class GroupRegistry extends Registry<Group> {
             value.overrides = value.overrides.concat(g.overrides);
         } else value.overrides = g.overrides;
       }
-      delete value.inherits;
     }
     this.executeHook({message: 'Register Group', data: {key, value}});
     this.items.push({key, value});

--- a/src/lib/util/config.ts
+++ b/src/lib/util/config.ts
@@ -10,6 +10,11 @@ export interface BotOptions {
   options?: ClientOptions;
 }
 
+export interface GroupOptions {
+  advanced: boolean;
+  levels?: Array<{id: string; level: number}>;
+}
+
 /**
  * The type interface for the bot configuration
  */
@@ -18,6 +23,7 @@ export interface BaseConfig {
   developers: Array<string>;
   logging?: LoggerOptions;
   database?: ConnectionOptions | 'external';
+  groups?: GroupOptions;
 }
 
 export interface ParserOptions {

--- a/src/lib/util/config.ts
+++ b/src/lib/util/config.ts
@@ -10,11 +10,6 @@ export interface BotOptions {
   options?: ClientOptions;
 }
 
-export interface GroupOptions {
-  advanced: boolean;
-  levels?: Array<{id: string; level: number}>;
-}
-
 /**
  * The type interface for the bot configuration
  */
@@ -23,7 +18,6 @@ export interface BaseConfig {
   developers: Array<string>;
   logging?: LoggerOptions;
   database?: ConnectionOptions | 'external';
-  groups?: GroupOptions;
 }
 
 export interface ParserOptions {

--- a/src/lib/util/hook.ts
+++ b/src/lib/util/hook.ts
@@ -18,8 +18,15 @@ export class Hookable {
   }
 }
 
-export const bindHooks = (hooks: Hookable[], callback: HookCallback) =>
-  hooks.forEach(h => h.hook(callback));
-
-export const unbindHooks = (hooks: Hookable[]) =>
-  hooks.forEach(h => h.unhook());
+export class Hook {
+  private callback: HookCallback;
+  constructor(callback: HookCallback) {
+    this.callback = callback;
+  }
+  bind(...hooks: Hookable[]) {
+    hooks.forEach(h => h.hook(this.callback));
+  }
+  unbind(...hooks: Hookable[]) {
+    hooks.forEach(h => h.unhook());
+  }
+}


### PR DESCRIPTION
- [x] Change command's from decorator based to classes
- [x] Add the ability to use "hooks" to get debug information from registries
- [x] Fix the ability to use custom configs with commands (fixes #80)
- [x] Change hook implementation from functions to a class
- [x] Add guard functionality to add pre-checks to commands
- [x] Don't delete the inherits field when inheriting groups 
- [ ] Add advanced level-based permission option 